### PR TITLE
Fix for checkhandle error

### DIFF
--- a/server/osargs.py
+++ b/server/osargs.py
@@ -72,7 +72,7 @@ def do_args_flush_open_files(a, x, y):
 def do_args_get_file_ptr(a, x, y):
 	log(2, "        get file #%d ptr" % y)
 
-	f = fs.checkhandle(y)
+	f = fs.getfile(y)
 	if not f:
 		send_code_error_channel()
 		return
@@ -88,7 +88,7 @@ def do_args_get_file_ptr(a, x, y):
 def do_args_set_file_ptr(a, x, y):
 	log(2, "        set file #%d ptr" % y)
 
-	f = fs.checkhandle(y)
+	f = fs.getfile(y)
 	if not f:
 		send_code_error_channel()
 		return
@@ -103,7 +103,7 @@ def do_args_set_file_ptr(a, x, y):
 def do_args_get_file_len(a, x, y):
 	log(2, "        get file #%d length" % y)
 
-	f = fs.checkhandle(y)
+	f = fs.getfile(y)
 	if not f:
 		send_code_error_channel()
 		return
@@ -119,7 +119,7 @@ def do_args_get_file_len(a, x, y):
 def do_args_flush_file(a, x, y):
 	log(2, "        flush file #%d" % y)
 
-	f = fs.checkhandle(y)
+	f = fs.getfile(y)
 	if not f:
 		send_code_error_channel()
 		return


### PR DESCRIPTION

It looks like during the file system refactor some instances of checkhandle weren't updated to getfile.

I have to admit I've not dug too deeply into what this does, but this change seems to fix it.

Original Error:

```
Traceback (most recent call last):
  File "/home/matthew/serialfs/server/serialfs-server.py", line 24, in <module>
    session.run()
  File "/home/matthew/serialfs/server/session.py", line 172, in run
    commands.do_command()
  File "/home/matthew/serialfs/server/commands.py", line 52, in do_command
    handlers[cmd](a, x, y)
  File "/home/matthew/serialfs/server/osargs.py", line 35, in do_args
    return do_args_get_file_len(a, x, y)
  File "/home/matthew/serialfs/server/osargs.py", line 106, in do_args_get_file_len
    f = fs.checkhandle(y)
AttributeError: module 'fs' has no attribute 'checkhandle'
```